### PR TITLE
Allow custom period when running workflow manually

### DIFF
--- a/.github/workflows/playlist.yml
+++ b/.github/workflows/playlist.yml
@@ -3,7 +3,12 @@ name: Playlist Automation
 on:
   schedule:
     - cron: '0 9 * * 1'   # Co poniedziałek o 9:00 UTC
-  workflow_dispatch:      # Możesz też odpalić ręcznie
+  workflow_dispatch:
+    inputs:
+      period:
+        description: "Okres historii (1day, 7day, 1month, 6month)"
+        required: false
+        default: "6month"
 
 jobs:
   build:
@@ -17,6 +22,8 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Generate Playlist
+        env:
+          PERIOD: ${{ github.event.inputs.period || '6month' }}
         run: python playlist_generator.py
       - name: Commit and push CSV
         run: |

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # lastfm-playlist-automation
-# test
+
+This repository automatically generates a playlist from Last.fm history.
+
+### Manual workflow usage
+
+When triggering the workflow manually (`Workflow Dispatch`), you'll be
+prompted for the time period used to fetch your top tracks. You can
+select one of the following options:
+
+- `1day`
+- `7day`
+- `1month`
+- `6month`
+
+If you leave the input empty, `6month` will be used by default.

--- a/playlist_generator.py
+++ b/playlist_generator.py
@@ -1,3 +1,4 @@
+import os
 import requests
 import pandas as pd
 import random
@@ -5,7 +6,7 @@ from collections import defaultdict
 
 API_KEY = "b5befec30db2e1875c0bbf5b9757d4b2"
 USER = "NostromoRock"
-PERIOD = "6month"
+PERIOD = os.getenv("PERIOD", "6month")
 LIMIT = 80
 
 # Pobierz top utwory z ostatnich 180 dni


### PR DESCRIPTION
## Summary
- add `PERIOD` env variable support in `playlist_generator.py`
- document manual workflow options in README
- add `period` input to workflow dispatch and forward it to the script

## Testing
- `python -m py_compile playlist_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_6887216bef8883318cebfc2819086e76