### PR TITLE
Improve Last.fm error handling in playlist generator

### DIFF
--- a/playlist_generator.py
+++ b/playlist_generator.py
@@ -1,25 +1,104 @@
 import os
-import requests
-import pandas as pd
-import random
 from collections import defaultdict
+
+import pandas as pd
+import requests
 
 API_KEY = "b5befec30db2e1875c0bbf5b9757d4b2"
 USER = "NostromoRock"
 PERIOD = os.getenv("PERIOD", "6month")
 LIMIT = 80
+API_URL = "http://ws.audioscrobbler.com/2.0/"
 
-# Pobierz top utwory z ostatnich 180 dni
-url = f"http://ws.audioscrobbler.com/2.0/?method=user.gettoptracks&user={USER}&api_key={API_KEY}&period={PERIOD}&limit={LIMIT}&format=json"
-response = requests.get(url)
-data = response.json()
 
-top_tracks = data['toptracks']['track']
-top_tracks_df = pd.DataFrame([{
-    'Utwór': track['name'],
-    'Artysta': track['artist']['name'],
-    'Scrobbles': int(track['playcount'])
-} for track in top_tracks])
+def call_lastfm(params: dict) -> dict:
+    """Call the Last.fm API and return JSON or raise a helpful error."""
+
+    default_params = {
+        "api_key": API_KEY,
+        "format": "json",
+    }
+    response = requests.get(API_URL, params={**default_params, **params}, timeout=30)
+    response.raise_for_status()
+    payload = response.json()
+
+    if "error" in payload:
+        raise RuntimeError(
+            f"Last.fm API error {payload['error']}: {payload.get('message', 'Unknown error')}"
+        )
+
+    return payload
+
+
+def get_top_tracks() -> pd.DataFrame:
+    """Return the user's top tracks for the configured period."""
+
+    data = call_lastfm(
+        {
+            "method": "user.gettoptracks",
+            "user": USER,
+            "period": PERIOD,
+            "limit": LIMIT,
+        }
+    )
+
+    top_tracks = data.get("toptracks", {}).get("track")
+    if not top_tracks:
+        raise RuntimeError(
+            "Last.fm did not return any top tracks. "
+            "Verify that the user exists and the PERIOD has listening data."
+        )
+
+    if isinstance(top_tracks, dict):
+        top_tracks = [top_tracks]
+
+    return pd.DataFrame(
+        [
+            {
+                "Utwór": track["name"],
+                "Artysta": track["artist"]["name"],
+                "Scrobbles": int(track["playcount"]),
+            }
+            for track in top_tracks
+        ]
+    )
+
+
+def fetch_similar_artists(artist: str) -> list[str]:
+    """Return the artist and up to two similar artists."""
+
+    similar_response = call_lastfm(
+        {
+            "method": "artist.getsimilar",
+            "artist": artist,
+            "limit": 2,
+        }
+    )
+
+    similar = [artist]
+    similar_data = similar_response.get("similarartists", {}).get("artist", [])
+    similar.extend([entry["name"] for entry in similar_data[:2]])
+    return similar
+
+
+def fetch_artist_top_tracks(artist: str) -> list[dict]:
+    """Return up to five top tracks for the given artist."""
+
+    tracks_response = call_lastfm(
+        {
+            "method": "artist.gettoptracks",
+            "artist": artist,
+            "limit": 5,
+        }
+    )
+
+    tracks = tracks_response.get("toptracks", {}).get("track", [])
+    if isinstance(tracks, dict):
+        tracks = [tracks]
+    return tracks
+
+
+top_tracks_df = get_top_tracks()
 
 # Losowe 1/3 z tych utworów
 chosen_top = top_tracks_df.sample(n=10, random_state=42)
@@ -27,44 +106,30 @@ chosen_top = top_tracks_df.sample(n=10, random_state=42)
 # 2/3 rekomendacje: max 2 utwory na artystę, także podobni artyści
 recommendations = []
 artist_counts = defaultdict(int)
-unique_artists = top_tracks_df['Artysta'].unique().tolist()
+unique_artists = top_tracks_df["Artysta"].unique().tolist()
 
 for artist in unique_artists:
     if len(recommendations) >= 20:
         break
-    # Dodaj podobnych artystów (2 podobnych + oryginał)
-    sim_url = f"http://ws.audioscrobbler.com/2.0/?method=artist.getsimilar&artist={artist}&api_key={API_KEY}&format=json&limit=2"
-    sim_resp = requests.get(sim_url).json()
-    similar_artists = [artist]
-    if "similarartists" in sim_resp and "artist" in sim_resp["similarartists"]:
-        similar_artists += [a['name'] for a in sim_resp["similarartists"]["artist"][:2]]
 
-    for sim_artist in similar_artists:
-        rec_url = f"http://ws.audioscrobbler.com/2.0/?method=artist.gettoptracks&artist={sim_artist}&api_key={API_KEY}&limit=5&format=json"
-        rec_response = requests.get(rec_url).json()
-        if "toptracks" in rec_response and "track" in rec_response["toptracks"]:
-            tracks = rec_response['toptracks']['track']
-            if isinstance(tracks, dict):
-                tracks = [tracks]
-            for track in tracks:
-                if (
-                    track['name'] not in top_tracks_df['Utwór'].values
-                    and artist_counts[sim_artist] < 2
-                ):
-                    recommendations.append({
-                        'Utwór': track['name'],
-                        'Artysta': sim_artist
-                    })
-                    artist_counts[sim_artist] += 1
-                    if len(recommendations) >= 20:
-                        break
-            if len(recommendations) >= 20:
-                break
+    for sim_artist in fetch_similar_artists(artist):
+        for track in fetch_artist_top_tracks(sim_artist):
+            if (
+                track["name"] not in top_tracks_df["Utwór"].values
+                and artist_counts[sim_artist] < 2
+            ):
+                recommendations.append({
+                    "Utwór": track["name"],
+                    "Artysta": sim_artist,
+                })
+                artist_counts[sim_artist] += 1
+                if len(recommendations) >= 20:
+                    break
         if len(recommendations) >= 20:
             break
 
 rec_df = pd.DataFrame(recommendations)
 
-playlist_df = pd.concat([chosen_top[['Utwór', 'Artysta']], rec_df], ignore_index=True)
-playlist_df.to_csv('playlist_lastfm.csv', index=False)
+playlist_df = pd.concat([chosen_top[["Utwór", "Artysta"]], rec_df], ignore_index=True)
+playlist_df.to_csv("playlist_lastfm.csv", index=False)
 print(playlist_df)


### PR DESCRIPTION
## Summary
- add a helper around the Last.fm API that checks HTTP errors and API error payloads
- validate that top tracks exist before building the playlist and reuse helpers for recommendations

## Testing
- python playlist_generator.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691aef910d9c8331804cc936c5bc4f83)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a robust Last.fm API helper and refactor playlist generation to use validated, modular functions for top tracks and recommendations.
> 
> - **Core / Last.fm API**:
>   - Add `API_URL` and `call_lastfm(...)` with timeout, HTTP error handling, and Last.fm error payload checks.
> - **Playlist generation**:
>   - Add `get_top_tracks()` with validation and DataFrame construction.
>   - Add `fetch_similar_artists()` and `fetch_artist_top_tracks()` helpers.
>   - Replace inline requests with helpers; enforce max 2 tracks per artist and cap at 20 recommendations; avoid duplicates with existing top tracks.
>   - Continue exporting playlist to `playlist_lastfm.csv`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a08a7d0063afe93df429c09860a0a1f849116486. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->